### PR TITLE
Enable Eleventy to re-build _site when content within a custom element is modified. 

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,4 +4,5 @@ module.exports = function (eleventyConfig) {
   let extension = 'html'
   eleventyConfig.addTemplateFormats(extension)
   eleventyConfig.addExtension(extension, plugin)
+  eleventyConfig.addWatchTarget("./elements/**/*.mjs")
 }

--- a/elements.mjs
+++ b/elements.mjs
@@ -1,7 +1,9 @@
-import header from './elements/my-header.mjs'
-import footer from './elements/my-footer.mjs'
+import { importWithoutCache } from './utils.js'
+
+const header = await importWithoutCache('./elements/my-header.mjs')
+const footer = await importWithoutCache('./elements/my-footer.mjs')
 
 export default {
-  'my-header': header,
-  'my-footer': footer
+  'my-header': header.default,
+  'my-footer': footer.default
 }

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,7 @@
 let enhance = require('./vendor/enhance-ssr.js')
 let { join } = require('path')
 let { existsSync: exists, readdirSync: ls } = require('fs')
+let { importWithoutCache } = require('./utils')
 
 module.exports = {
   async compile (inputContent) {
@@ -19,7 +20,7 @@ async function read () {
 
   if (exists(pathToModule)) {
     // read explicit elements manifest
-    let els = await import(pathToModule)
+    let els = await importWithoutCache(pathToModule)
     return els.default || els
   }
   else if (exists(pathToDirectory)) {
@@ -28,7 +29,7 @@ async function read () {
     let raw = ls(pathToDirectory)
     for (let e of raw) {
       let tag = e.replace('.mjs', '')
-      let mod = await import(join(pathToDirectory, e))
+      let mod = await importWithoutCache(join(pathToDirectory, e))
       els[tag] = mod.default
     }
     return els

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ module.exports = function (eleventyConfig) {
   let extension = 'html'
   eleventyConfig.addTemplateFormats(extension)
   eleventyConfig.addExtension(extension, plugin)
+  eleventyConfig.addWatchTarget("./elements/**/*.mjs")
 }
 ```
 

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,5 @@
+const importWithoutCache = async (path) => {
+    return await import(`${path}?cacheBust=${Date.now()}`)
+}
+
+exports.importWithoutCache = importWithoutCache;


### PR DESCRIPTION
Currently Eleventy only re-builds and updates the browser while serving locally if content is modified within a `.html` file. 

There's two things preventing this from happening. 

1. Eleventy doesn't know to watch the `/elements` directory
1. The dynamic import statements return a cached version of the custom element's module script. 

This PR does the following:

#### Updates the Eleventy config file to inform the watcher service about the custom elements dir
```javascript
eleventyConfig.addWatchTarget("./elements/**/*.mjs");
````

#### Adds a helper function that provides a cache busting mechanism* for import paths.  
- new file named `utils.js` with the dynamic import statement importWithoutCache
- Previous usage of `await import ...` have been replaced with `await importWithoutCache ...` maintaining the original path
- Additionally the `elements.mjs` file has been modified to use the helper function, as these dependencies were also cached 


(*) I was concerned the `Date.now()` was a little uncouth, but it does the job. Happy to change if you have a more desirable random / unique string mechanism in mind 